### PR TITLE
Revert "nodejs version compatible with gitbook-cli"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: '12.18.2'
+          node-version: 12
       - run: sudo apt update
       - run: sudo apt install calibre-bin
       - run: sudo npm install -g gitbook-cli


### PR DESCRIPTION
to trigger Actions again 🤷‍♂️